### PR TITLE
Automatically send Rails logs to AppInsights

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.4
+  - 2.5
+  - 2.6
 
 before_install:
   - gem install dep

--- a/lib/appinsights.rb
+++ b/lib/appinsights.rb
@@ -3,6 +3,7 @@ require_relative 'appinsights/errors'
 require_relative 'appinsights/context'
 require_relative 'appinsights/middlewares'
 require_relative 'appinsights/config_loader'
+require_relative 'appinsights/logger_proxy'
 require_relative 'appinsights/installers/base'
 
 module AppInsights

--- a/lib/appinsights/installers/rails.rb
+++ b/lib/appinsights/installers/rails.rb
@@ -13,6 +13,8 @@ module AppInsights
                                                  Rails.logger
 
       installer.install
+
+      Rails.logger = AppInsights::LoggerProxy.new Rails.logger
     end
   end
 end

--- a/lib/appinsights/logger_proxy.rb
+++ b/lib/appinsights/logger_proxy.rb
@@ -1,0 +1,54 @@
+require 'application_insights'
+
+module AppInsights
+  class LoggerProxy < Object
+    @@severity_levels = {
+      :debug => ApplicationInsights::Channel::Contracts::SeverityLevel::VERBOSE,
+      :info => ApplicationInsights::Channel::Contracts::SeverityLevel::INFORMATION,
+      :warn => ApplicationInsights::Channel::Contracts::SeverityLevel::WARNING,
+      :error => ApplicationInsights::Channel::Contracts::SeverityLevel::ERROR,
+      :fatal => ApplicationInsights::Channel::Contracts::SeverityLevel::CRITICAL,
+      :unknown => ApplicationInsights::Channel::Contracts::SeverityLevel::CRITICAL,
+    }
+
+    def initialize(logger, ignore_log_level=false, telemetry_client=nil)
+      @logger = logger
+      @ignore_log_level = ignore_log_level
+      @telemetry_client = telemetry_client
+
+      %w(debug info warn error fatal unknown).each do |level|
+        LoggerProxy.class_eval do
+          define_method level.to_sym do |*args , &block|
+            if !@ignore_log_level && !logger.send("#{level}?".to_sym)
+              return true
+            end
+
+            msg = message(*args, &block)
+            tc = @telemetry_client || AppInsights::Context.telemetry_client
+            tc.track_trace(msg, @@severity_levels[level.to_sym])
+            @logger.send(level, msg, &block)
+          end
+        end
+      end
+    end
+
+    protected
+
+    def method_missing(name, *args, &block)
+      @logger.send(name, *args, &block)
+    end
+
+    private
+
+    def message(*args, &block)
+      if block_given?
+        block.call
+      else
+        args = args.flatten.compact
+        args = (args.count == 1 ? args[0] : args)
+        args.is_a?(Proc) ? args.call : args
+      end
+    end
+
+  end
+end

--- a/test/config/async_file.toml
+++ b/test/config/async_file.toml
@@ -1,0 +1,6 @@
+[ai]
+  instrumentation_key = 'cccccccc-cccc-cccc-cccc'
+  async = true
+  async_send_interval_seconds = 1
+  async_send_buffer_size = 2
+  async_max_queue_length = 3

--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -62,5 +62,18 @@ describe AppInsights::ConfigLoader do
       deny settings.empty?
       deny middlewares.empty?
     end
+
+    it 'autoconfigure the Context as async' do
+      AppInsights::ConfigLoader.new './test/config', 'async_file.toml'
+
+      tc = AppInsights::Context.telemetry_client
+
+      assert tc.context.instrumentation_key
+      assert_equal 'ApplicationInsights::Channel::AsynchronousQueue', tc.channel.queue.class.name
+      assert_equal 'ApplicationInsights::Channel::AsynchronousSender', tc.channel.queue.sender.class.name
+      assert_equal 1, tc.channel.queue.sender.send_interval
+      assert_equal 2, tc.channel.queue.sender.send_buffer_size
+      assert_equal 3, tc.channel.queue.max_queue_length
+    end
   end
 end

--- a/test/logger_proxy_test.rb
+++ b/test/logger_proxy_test.rb
@@ -1,0 +1,43 @@
+require 'application_insights'
+require_relative 'mock/mock_logger'
+require_relative 'mock/mock_telemetry_client'
+
+describe AppInsights::LoggerProxy do
+  before do
+    @client = MockTelemetryClient.new
+    @logger = MockLogger.new
+  end
+
+  describe 'log' do
+    it 'sends traces to AppInsights' do
+      proxy = AppInsights::LoggerProxy.new(@logger, false, @client)
+      proxy.level = :info
+
+      proxy.info('a info message')
+
+      assert_equal 1, @logger.messages.length
+      assert_equal [Logger::INFO, nil, 'a info message'], @logger.messages.first[0, 3]
+      assert_equal 1, @client.traces.length
+      assert_equal ['a info message', ApplicationInsights::Channel::Contracts::SeverityLevel::INFORMATION], @client.traces.first
+    end
+
+    it 'does not send traces to AppInsights if the log level is too low' do
+      proxy = AppInsights::LoggerProxy.new(@logger, false, @client)
+      proxy.level = :warn
+
+      proxy.debug('a debug message')
+
+      assert @client.traces.empty?
+    end
+
+    it 'sends traces to AppInsights for low log level when telemetry sending is forced' do
+      proxy = AppInsights::LoggerProxy.new(@logger, true, @client)
+      proxy.level = :warn
+
+      proxy.debug('a debug message')
+
+      assert_equal 1, @client.traces.length
+      assert_equal ['a debug message', ApplicationInsights::Channel::Contracts::SeverityLevel::VERBOSE], @client.traces.first
+    end
+  end
+end

--- a/test/mock/mock_logger.rb
+++ b/test/mock/mock_logger.rb
@@ -8,6 +8,6 @@ class MockLogger < Logger
   end
 
   def add(severity, message = nil, progname = nil, &block)
-    @messages << [severity, messages, progname, block]
+    @messages << [severity, message, progname, block]
   end
 end

--- a/test/mock/mock_telemetry_client.rb
+++ b/test/mock/mock_telemetry_client.rb
@@ -1,0 +1,11 @@
+class MockTelemetryClient
+  attr_reader :traces
+
+  def initialize
+    @traces = []
+  end
+
+  def track_trace(message, severity)
+    @traces << [message, severity]
+  end
+end


### PR DESCRIPTION
Currently this gem enables Rails applications to send telemetry such as requests and exceptions to Azure Application Insights, via [ApplicationInsights::Rack::TrackRequest](https://github.com/microsoft/ApplicationInsights-Ruby/blob/5db6b4ad65262d23f26b678143a4a1fd7939e5c2/lib/application_insights/rack/track_request.rb) and [AppInsights::ExceptionHandling](https://github.com/citrusbyte/appinsights/blob/938dfc41c9b5338229573d1e4f958f57a2b855cd/lib/appinsights/middlewares/exception_handling.rb) respectively. To make it even easier to debug of Rails applications that use this gem, this pull request augments the existing functionality to also send logs to the Application Insights via the [TrackTrace API](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#tracktrace). AppInsights plugins for other popular server frameworks implement similar functionality, e.g. refer to the plugins for [Flask](https://github.com/microsoft/ApplicationInsights-Python/blob/c9d56ab404a9ce00398430e45aa5acaa761c681e/applicationinsights/flask/ext.py#L137-L153) and [Django](https://github.com/microsoft/ApplicationInsights-Python/blob/c9d56ab404a9ce00398430e45aa5acaa761c681e/applicationinsights/django/logging.py#L7-L45).

To reduce the performance impact of turning on log shipping, this pull request also adds a configuration option to make the calls to the application_insights SDK non-blocking and have a background thread perform the HTTP requests to the Application Insights service.